### PR TITLE
core/vm: port custom precompile support to v1.16.8

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -490,7 +490,7 @@ func (st *stateTransition) execute() (*ExecutionResult, error) {
 	// Execute the preparatory steps for state transition which includes:
 	// - prepare accessList(post-berlin)
 	// - reset transient storage(eip 1153)
-	st.state.Prepare(rules, msg.From, st.evm.Context.Coinbase, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
+	st.state.Prepare(rules, msg.From, st.evm.Context.Coinbase, msg.To, st.evm.ActivePrecompiles(rules), msg.AccessList)
 
 	var (
 		ret   []byte

--- a/core/vm/contract.go
+++ b/core/vm/contract.go
@@ -22,6 +22,17 @@ import (
 	"github.com/holiman/uint256"
 )
 
+// ContractRef is a reference to a contract-like object by address.
+type ContractRef interface {
+	Address() common.Address
+}
+
+// AccountRef implements ContractRef.
+type AccountRef common.Address
+
+// Address casts AccountRef to common.Address.
+func (ar AccountRef) Address() common.Address { return common.Address(ar) }
+
 // Contract represents an ethereum contract in the state database. It contains
 // the contract code, calling arguments. Contract implements ContractRef
 type Contract struct {
@@ -42,8 +53,9 @@ type Contract struct {
 	IsDeployment bool
 	IsSystemCall bool
 
-	Gas   uint64
-	value *uint256.Int
+	Gas          uint64
+	value        *uint256.Int
+	isPrecompile bool
 }
 
 // NewContract returns a new contract environment for the execution of EVM.
@@ -61,7 +73,33 @@ func NewContract(caller common.Address, address common.Address, value *uint256.I
 	}
 }
 
+// NewPrecompile returns a new instance of a precompiled contract environment for the execution of EVM.
+func NewPrecompile(caller, object ContractRef, value *uint256.Int, gas uint64) *Contract {
+	c := &Contract{
+		caller:       caller.Address(),
+		address:      object.Address(),
+		isPrecompile: true,
+	}
+
+	// Gas should be a pointer so it can safely be reduced through the run
+	// This pointer will be off the state transition
+	c.Gas = gas
+	// ensures a value is set
+	c.value = value
+
+	return c
+}
+
+// IsPrecompile returns true if the contract is a precompiled contract environment
+func (c Contract) IsPrecompile() bool {
+	return c.isPrecompile
+}
+
 func (c *Contract) validJumpdest(dest *uint256.Int) bool {
+	if c.isPrecompile {
+		return false
+	}
+
 	udest, overflow := dest.Uint64WithOverflow()
 	// PC cannot go beyond len(code) and certainly can't be bigger than 63bits.
 	// Don't bother checking for JUMPDEST in that case.
@@ -78,6 +116,10 @@ func (c *Contract) validJumpdest(dest *uint256.Int) bool {
 // isCode returns true if the provided PC location is an actual opcode, as
 // opposed to a data-segment following a PUSHN operation.
 func (c *Contract) isCode(udest uint64) bool {
+	if c.isPrecompile {
+		return false
+	}
+
 	// Do we already have an analysis laying around?
 	if c.analysis != nil {
 		return c.analysis.codeSegment(udest)
@@ -160,6 +202,9 @@ func (c *Contract) Value() *uint256.Int {
 
 // SetCallCode sets the code of the contract,
 func (c *Contract) SetCallCode(hash common.Hash, code []byte) {
+	if c.isPrecompile {
+		return
+	}
 	c.Code = code
 	c.CodeHash = hash
 }

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -17,6 +17,7 @@
 package vm
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -48,8 +49,9 @@ import (
 // requires a deterministic gas count based on the input size of the Run method of the
 // contract.
 type PrecompiledContract interface {
-	RequiredGas(input []byte) uint64  // RequiredPrice calculates the contract gas use
-	Run(input []byte) ([]byte, error) // Run runs the precompiled contract
+	Address() common.Address
+	RequiredGas(input []byte) uint64                                 // RequiredPrice calculates the contract gas use
+	Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) // Run runs the precompiled contract
 	Name() string
 }
 
@@ -59,88 +61,88 @@ type PrecompiledContracts map[common.Address]PrecompiledContract
 // PrecompiledContractsHomestead contains the default set of pre-compiled Ethereum
 // contracts used in the Frontier and Homestead releases.
 var PrecompiledContractsHomestead = PrecompiledContracts{
-	common.BytesToAddress([]byte{0x1}): &ecrecover{},
-	common.BytesToAddress([]byte{0x2}): &sha256hash{},
-	common.BytesToAddress([]byte{0x3}): &ripemd160hash{},
-	common.BytesToAddress([]byte{0x4}): &dataCopy{},
+	ecrecover{}.Address():     &ecrecover{},
+	sha256hash{}.Address():    &sha256hash{},
+	ripemd160hash{}.Address(): &ripemd160hash{},
+	dataCopy{}.Address():      &dataCopy{},
 }
 
 // PrecompiledContractsByzantium contains the default set of pre-compiled Ethereum
 // contracts used in the Byzantium release.
 var PrecompiledContractsByzantium = PrecompiledContracts{
-	common.BytesToAddress([]byte{0x1}): &ecrecover{},
-	common.BytesToAddress([]byte{0x2}): &sha256hash{},
-	common.BytesToAddress([]byte{0x3}): &ripemd160hash{},
-	common.BytesToAddress([]byte{0x4}): &dataCopy{},
-	common.BytesToAddress([]byte{0x5}): &bigModExp{eip2565: false, eip7823: false, eip7883: false},
-	common.BytesToAddress([]byte{0x6}): &bn256AddByzantium{},
-	common.BytesToAddress([]byte{0x7}): &bn256ScalarMulByzantium{},
-	common.BytesToAddress([]byte{0x8}): &bn256PairingByzantium{},
+	ecrecover{}.Address():     &ecrecover{},
+	sha256hash{}.Address():    &sha256hash{},
+	ripemd160hash{}.Address(): &ripemd160hash{},
+	dataCopy{}.Address():      &dataCopy{},
+	bigModExp{}.Address():     &bigModExp{eip2565: false, eip7823: false, eip7883: false},
+	bn256AddByzantium{}.Address():       &bn256AddByzantium{},
+	bn256ScalarMulByzantium{}.Address(): &bn256ScalarMulByzantium{},
+	bn256PairingByzantium{}.Address():   &bn256PairingByzantium{},
 }
 
 // PrecompiledContractsIstanbul contains the default set of pre-compiled Ethereum
 // contracts used in the Istanbul release.
 var PrecompiledContractsIstanbul = PrecompiledContracts{
-	common.BytesToAddress([]byte{0x1}): &ecrecover{},
-	common.BytesToAddress([]byte{0x2}): &sha256hash{},
-	common.BytesToAddress([]byte{0x3}): &ripemd160hash{},
-	common.BytesToAddress([]byte{0x4}): &dataCopy{},
-	common.BytesToAddress([]byte{0x5}): &bigModExp{eip2565: false, eip7823: false, eip7883: false},
-	common.BytesToAddress([]byte{0x6}): &bn256AddIstanbul{},
-	common.BytesToAddress([]byte{0x7}): &bn256ScalarMulIstanbul{},
-	common.BytesToAddress([]byte{0x8}): &bn256PairingIstanbul{},
-	common.BytesToAddress([]byte{0x9}): &blake2F{},
+	ecrecover{}.Address():     &ecrecover{},
+	sha256hash{}.Address():    &sha256hash{},
+	ripemd160hash{}.Address(): &ripemd160hash{},
+	dataCopy{}.Address():      &dataCopy{},
+	bigModExp{}.Address():     &bigModExp{eip2565: false, eip7823: false, eip7883: false},
+	bn256AddIstanbul{}.Address():       &bn256AddIstanbul{},
+	bn256ScalarMulIstanbul{}.Address(): &bn256ScalarMulIstanbul{},
+	bn256PairingIstanbul{}.Address():   &bn256PairingIstanbul{},
+	blake2F{}.Address():                &blake2F{},
 }
 
 // PrecompiledContractsBerlin contains the default set of pre-compiled Ethereum
 // contracts used in the Berlin release.
 var PrecompiledContractsBerlin = PrecompiledContracts{
-	common.BytesToAddress([]byte{0x1}): &ecrecover{},
-	common.BytesToAddress([]byte{0x2}): &sha256hash{},
-	common.BytesToAddress([]byte{0x3}): &ripemd160hash{},
-	common.BytesToAddress([]byte{0x4}): &dataCopy{},
-	common.BytesToAddress([]byte{0x5}): &bigModExp{eip2565: true, eip7823: false, eip7883: false},
-	common.BytesToAddress([]byte{0x6}): &bn256AddIstanbul{},
-	common.BytesToAddress([]byte{0x7}): &bn256ScalarMulIstanbul{},
-	common.BytesToAddress([]byte{0x8}): &bn256PairingIstanbul{},
-	common.BytesToAddress([]byte{0x9}): &blake2F{},
+	ecrecover{}.Address():              &ecrecover{},
+	sha256hash{}.Address():             &sha256hash{},
+	ripemd160hash{}.Address():          &ripemd160hash{},
+	dataCopy{}.Address():               &dataCopy{},
+	bigModExp{}.Address():              &bigModExp{eip2565: true},
+	bn256AddIstanbul{}.Address():       &bn256AddIstanbul{},
+	bn256ScalarMulIstanbul{}.Address(): &bn256ScalarMulIstanbul{},
+	bn256PairingIstanbul{}.Address():   &bn256PairingIstanbul{},
+	blake2F{}.Address():                &blake2F{},
 }
 
 // PrecompiledContractsCancun contains the default set of pre-compiled Ethereum
 // contracts used in the Cancun release.
 var PrecompiledContractsCancun = PrecompiledContracts{
-	common.BytesToAddress([]byte{0x1}): &ecrecover{},
-	common.BytesToAddress([]byte{0x2}): &sha256hash{},
-	common.BytesToAddress([]byte{0x3}): &ripemd160hash{},
-	common.BytesToAddress([]byte{0x4}): &dataCopy{},
-	common.BytesToAddress([]byte{0x5}): &bigModExp{eip2565: true, eip7823: false, eip7883: false},
-	common.BytesToAddress([]byte{0x6}): &bn256AddIstanbul{},
-	common.BytesToAddress([]byte{0x7}): &bn256ScalarMulIstanbul{},
-	common.BytesToAddress([]byte{0x8}): &bn256PairingIstanbul{},
-	common.BytesToAddress([]byte{0x9}): &blake2F{},
-	common.BytesToAddress([]byte{0xa}): &kzgPointEvaluation{},
+	ecrecover{}.Address():              &ecrecover{},
+	sha256hash{}.Address():             &sha256hash{},
+	ripemd160hash{}.Address():          &ripemd160hash{},
+	dataCopy{}.Address():               &dataCopy{},
+	bigModExp{}.Address():              &bigModExp{eip2565: true},
+	bn256AddIstanbul{}.Address():       &bn256AddIstanbul{},
+	bn256ScalarMulIstanbul{}.Address(): &bn256ScalarMulIstanbul{},
+	bn256PairingIstanbul{}.Address():   &bn256PairingIstanbul{},
+	blake2F{}.Address():                &blake2F{},
+	kzgPointEvaluation{}.Address():     &kzgPointEvaluation{},
 }
 
 // PrecompiledContractsPrague contains the set of pre-compiled Ethereum
 // contracts used in the Prague release.
 var PrecompiledContractsPrague = PrecompiledContracts{
-	common.BytesToAddress([]byte{0x01}): &ecrecover{},
-	common.BytesToAddress([]byte{0x02}): &sha256hash{},
-	common.BytesToAddress([]byte{0x03}): &ripemd160hash{},
-	common.BytesToAddress([]byte{0x04}): &dataCopy{},
-	common.BytesToAddress([]byte{0x05}): &bigModExp{eip2565: true, eip7823: false, eip7883: false},
-	common.BytesToAddress([]byte{0x06}): &bn256AddIstanbul{},
-	common.BytesToAddress([]byte{0x07}): &bn256ScalarMulIstanbul{},
-	common.BytesToAddress([]byte{0x08}): &bn256PairingIstanbul{},
-	common.BytesToAddress([]byte{0x09}): &blake2F{},
-	common.BytesToAddress([]byte{0x0a}): &kzgPointEvaluation{},
-	common.BytesToAddress([]byte{0x0b}): &bls12381G1Add{},
-	common.BytesToAddress([]byte{0x0c}): &bls12381G1MultiExp{},
-	common.BytesToAddress([]byte{0x0d}): &bls12381G2Add{},
-	common.BytesToAddress([]byte{0x0e}): &bls12381G2MultiExp{},
-	common.BytesToAddress([]byte{0x0f}): &bls12381Pairing{},
-	common.BytesToAddress([]byte{0x10}): &bls12381MapG1{},
-	common.BytesToAddress([]byte{0x11}): &bls12381MapG2{},
+	ecrecover{}.Address():              &ecrecover{},
+	sha256hash{}.Address():             &sha256hash{},
+	ripemd160hash{}.Address():          &ripemd160hash{},
+	dataCopy{}.Address():               &dataCopy{},
+	bigModExp{}.Address():              &bigModExp{eip2565: true},
+	bn256AddIstanbul{}.Address():       &bn256AddIstanbul{},
+	bn256ScalarMulIstanbul{}.Address(): &bn256ScalarMulIstanbul{},
+	bn256PairingIstanbul{}.Address():   &bn256PairingIstanbul{},
+	blake2F{}.Address():                &blake2F{},
+	kzgPointEvaluation{}.Address():     &kzgPointEvaluation{},
+	bls12381G1Add{}.Address():          &bls12381G1Add{},
+	bls12381G1MultiExp{}.Address():     &bls12381G1MultiExp{},
+	bls12381G2Add{}.Address():          &bls12381G2Add{},
+	bls12381G2MultiExp{}.Address():     &bls12381G2MultiExp{},
+	bls12381Pairing{}.Address():        &bls12381Pairing{},
+	bls12381MapG1{}.Address():          &bls12381MapG1{},
+	bls12381MapG2{}.Address():          &bls12381MapG2{},
 }
 
 var PrecompiledContractsBLS = PrecompiledContractsPrague
@@ -237,8 +239,8 @@ func ActivePrecompiledContracts(rules params.Rules) PrecompiledContracts {
 	return maps.Clone(activePrecompiledContracts(rules))
 }
 
-// ActivePrecompiles returns the precompile addresses enabled with the current configuration.
-func ActivePrecompiles(rules params.Rules) []common.Address {
+// DefaultActivePrecompiles returns the set of precompiles enabled with the default configuration.
+func DefaultActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
 	case rules.IsOsaka:
 		return PrecompiledAddressesOsaka
@@ -257,53 +259,176 @@ func ActivePrecompiles(rules params.Rules) []common.Address {
 	}
 }
 
+// ActivePrecompiles is kept as a compatibility alias.
+func ActivePrecompiles(rules params.Rules) []common.Address {
+	return DefaultActivePrecompiles(rules)
+}
+
+// DefaultPrecompiles define the mapping of address and precompiles from the default configuration
+func DefaultPrecompiles(rules params.Rules) (precompiles map[common.Address]PrecompiledContract) {
+	switch {
+	case rules.IsPrague:
+		precompiles = PrecompiledContractsPrague
+	case rules.IsCancun:
+		precompiles = PrecompiledContractsCancun
+	case rules.IsBerlin:
+		precompiles = PrecompiledContractsBerlin
+	case rules.IsIstanbul:
+		precompiles = PrecompiledContractsIstanbul
+	case rules.IsByzantium:
+		precompiles = PrecompiledContractsByzantium
+	default:
+		precompiles = PrecompiledContractsHomestead
+	}
+
+	return precompiles
+}
+
+// ActivePrecompiles returns the precompiles enabled with the current configuration.
+//
+// NOTE: The rules argument is ignored as the active precompiles can be set via the WithPrecompiles
+// method according to the chain rules from the current block context.
+func (evm *EVM) ActivePrecompiles(rules params.Rules) []common.Address {
+	return evm.activePrecompiles
+}
+
+// Precompile returns a precompiled contract for the given address. This
+// function returns false if the address is not a registered precompile.
+func (evm *EVM) Precompile(addr common.Address) (PrecompiledContract, bool) {
+	p, ok := evm.precompiles[addr]
+	return p, ok
+}
+
+// WithPrecompiles sets the precompiled contracts and the slice of actives precompiles.
+// IMPORTANT: This function does NOT validate the precompiles provided to the EVM. The caller should
+// use the ValidatePrecompiles function for this purpose prior to calling WithPrecompiles.
+func (evm *EVM) WithPrecompiles(
+	precompiles map[common.Address]PrecompiledContract,
+	activePrecompiles []common.Address,
+) {
+	evm.precompiles = precompiles
+	evm.activePrecompiles = activePrecompiles
+}
+
+// ValidatePrecompiles validates the precompile map against the active
+// precompile slice.
+// It returns an error if the precompiled contract map has a different length
+// than the slice of active contract addresses. This function also checks for
+// duplicates, invalid addresses and empty precompile contract instances.
+func ValidatePrecompiles(
+	precompiles map[common.Address]PrecompiledContract,
+	activePrecompiles []common.Address,
+) error {
+	if len(precompiles) != len(activePrecompiles) {
+		return fmt.Errorf("precompiles length mismatch (expected %d, got %d)", len(precompiles), len(activePrecompiles))
+	}
+
+	dupActivePrecompiles := make(map[common.Address]bool)
+
+	for _, addr := range activePrecompiles {
+		if dupActivePrecompiles[addr] {
+			return fmt.Errorf("duplicate active precompile: %s", addr)
+		}
+
+		precompile, ok := precompiles[addr]
+		if !ok {
+			return fmt.Errorf("active precompile address doesn't exist in precompiles map: %s", addr)
+		}
+
+		if precompile == nil {
+			return fmt.Errorf("precompile contract cannot be nil: %s", addr)
+		}
+
+		if bytes.Equal(addr.Bytes(), common.Address{}.Bytes()) {
+			return fmt.Errorf("precompile cannot be the zero address: %s", addr)
+		}
+
+		dupActivePrecompiles[addr] = true
+	}
+
+	return nil
+}
+
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.
 // It returns
 // - the returned bytes,
 // - the _remaining_ gas,
 // - any error that occurred
-func RunPrecompiledContract(p PrecompiledContract, input []byte, suppliedGas uint64, logger *tracing.Hooks) (ret []byte, remainingGas uint64, err error) {
+func (evm *EVM) RunPrecompiledContract(
+	p PrecompiledContract,
+	caller ContractRef,
+	input []byte,
+	suppliedGas uint64,
+	value *uint256.Int,
+	readOnly bool,
+) (ret []byte, remainingGas uint64, err error) {
+	return runPrecompiledContract(evm, p, caller, input, suppliedGas, value, readOnly)
+}
+
+func runPrecompiledContract(
+	evm *EVM,
+	p PrecompiledContract,
+	caller ContractRef,
+	input []byte,
+	suppliedGas uint64,
+	value *uint256.Int,
+	readOnly bool,
+) (ret []byte, remainingGas uint64, err error) {
+	addrCopy := p.Address()
+	inputCopy := make([]byte, len(input))
+	copy(inputCopy, input)
+
+	contract := NewPrecompile(caller, AccountRef(addrCopy), value, suppliedGas)
+	contract.Input = inputCopy
+
 	gasCost := p.RequiredGas(input)
-	if suppliedGas < gasCost {
-		return nil, 0, ErrOutOfGas
+	var tracer *tracing.Hooks
+	if evm != nil {
+		tracer = evm.Config.Tracer
 	}
-	if logger != nil && logger.OnGasChange != nil {
-		logger.OnGasChange(suppliedGas, suppliedGas-gasCost, tracing.GasChangeCallPrecompiledContract)
+	if !contract.UseGas(gasCost, tracer, tracing.GasChangeCallPrecompiledContract) {
+		return nil, contract.Gas, ErrOutOfGas
 	}
-	suppliedGas -= gasCost
-	output, err := p.Run(input)
-	return output, suppliedGas, err
+
+	output, err := p.Run(evm, contract, readOnly)
+	return output, contract.Gas, err
 }
 
 // ecrecover implemented as a native contract.
 type ecrecover struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (ecrecover) Address() common.Address {
+	return common.BytesToAddress([]byte{1})
+}
+
 func (c *ecrecover) RequiredGas(input []byte) uint64 {
 	return params.EcrecoverGas
 }
 
-func (c *ecrecover) Run(input []byte) ([]byte, error) {
+func (c *ecrecover) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	const ecRecoverInputLength = 128
 
-	input = common.RightPadBytes(input, ecRecoverInputLength)
+	contract.Input = common.RightPadBytes(contract.Input, ecRecoverInputLength)
 	// "input" is (hash, v, r, s), each 32 bytes
 	// but for ecrecover we want (r, s, v)
 
-	r := new(big.Int).SetBytes(input[64:96])
-	s := new(big.Int).SetBytes(input[96:128])
-	v := input[63] - 27
+	r := new(big.Int).SetBytes(contract.Input[64:96])
+	s := new(big.Int).SetBytes(contract.Input[96:128])
+	v := contract.Input[63] - 27
 
 	// tighter sig s values input homestead only apply to tx sigs
-	if bitutil.TestBytes(input[32:63]) || !crypto.ValidateSignatureValues(v, r, s, false) {
+	if bitutil.TestBytes(contract.Input[32:63]) || !crypto.ValidateSignatureValues(v, r, s, false) {
 		return nil, nil
 	}
 	// We must make sure not to modify the 'input', so placing the 'v' along with
 	// the signature needs to be done on a new allocation
 	sig := make([]byte, 65)
-	copy(sig, input[64:128])
+	copy(sig, contract.Input[64:128])
 	sig[64] = v
 	// v needs to be at the end for libsecp256k1
-	pubKey, err := crypto.Ecrecover(input[:32], sig)
+	pubKey, err := crypto.Ecrecover(contract.Input[:32], sig)
 	// make sure the public key is a valid one
 	if err != nil {
 		return nil, nil
@@ -320,6 +445,12 @@ func (c *ecrecover) Name() string {
 // SHA256 implemented as a native contract.
 type sha256hash struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (sha256hash) Address() common.Address {
+	return common.BytesToAddress([]byte{2})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 //
 // This method does not require any overflow checking as the input size gas costs
@@ -327,8 +458,8 @@ type sha256hash struct{}
 func (c *sha256hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Sha256PerWordGas + params.Sha256BaseGas
 }
-func (c *sha256hash) Run(input []byte) ([]byte, error) {
-	h := sha256.Sum256(input)
+func (c *sha256hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	h := sha256.Sum256(contract.Input)
 	return h[:], nil
 }
 
@@ -339,6 +470,12 @@ func (c *sha256hash) Name() string {
 // RIPEMD160 implemented as a native contract.
 type ripemd160hash struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (ripemd160hash) Address() common.Address {
+	return common.BytesToAddress([]byte{3})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 //
 // This method does not require any overflow checking as the input size gas costs
@@ -346,9 +483,9 @@ type ripemd160hash struct{}
 func (c *ripemd160hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Ripemd160PerWordGas + params.Ripemd160BaseGas
 }
-func (c *ripemd160hash) Run(input []byte) ([]byte, error) {
+func (c *ripemd160hash) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	ripemd := ripemd160.New()
-	ripemd.Write(input)
+	ripemd.Write(contract.Input)
 	return common.LeftPadBytes(ripemd.Sum(nil), 32), nil
 }
 
@@ -359,6 +496,13 @@ func (c *ripemd160hash) Name() string {
 // data copy implemented as a native contract.
 type dataCopy struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (dataCopy) Address() common.Address {
+	return common.BytesToAddress([]byte{4})
+}
+
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 //
 // This method does not require any overflow checking as the input size gas costs
@@ -366,8 +510,8 @@ type dataCopy struct{}
 func (c *dataCopy) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
-func (c *dataCopy) Run(in []byte) ([]byte, error) {
-	return common.CopyBytes(in), nil
+func (c *dataCopy) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	return common.CopyBytes(contract.Input), nil
 }
 
 func (c *dataCopy) Name() string {
@@ -557,6 +701,12 @@ func osakaModexpGas(baseLen, expLen, modLen uint64, expHead uint256.Int) uint64 
 	return max(gas, minGas)
 }
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bigModExp) Address() common.Address {
+	return common.BytesToAddress([]byte{5})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bigModExp) RequiredGas(input []byte) uint64 {
 	// Parse input lengths
@@ -606,20 +756,20 @@ func (c *bigModExp) RequiredGas(input []byte) uint64 {
 	}
 }
 
-func (c *bigModExp) Run(input []byte) ([]byte, error) {
+func (c *bigModExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	var (
-		baseLenBig       = new(big.Int).SetBytes(getData(input, 0, 32))
-		expLenBig        = new(big.Int).SetBytes(getData(input, 32, 32))
-		modLenBig        = new(big.Int).SetBytes(getData(input, 64, 32))
+		baseLenBig       = new(big.Int).SetBytes(getData(contract.Input, 0, 32))
+		expLenBig        = new(big.Int).SetBytes(getData(contract.Input, 32, 32))
+		modLenBig        = new(big.Int).SetBytes(getData(contract.Input, 64, 32))
 		baseLen          = baseLenBig.Uint64()
 		expLen           = expLenBig.Uint64()
 		modLen           = modLenBig.Uint64()
 		inputLenOverflow = max(baseLenBig.BitLen(), expLenBig.BitLen(), modLenBig.BitLen()) > 64
 	)
-	if len(input) > 96 {
-		input = input[96:]
+	if len(contract.Input) > 96 {
+		contract.Input = contract.Input[96:]
 	} else {
-		input = input[:0]
+		contract.Input = contract.Input[:0]
 	}
 
 	// enforce size cap for inputs
@@ -632,9 +782,9 @@ func (c *bigModExp) Run(input []byte) ([]byte, error) {
 	}
 	// Retrieve the operands and execute the exponentiation
 	var (
-		base = new(patched_big.Int).SetBytes(getData(input, 0, baseLen))
-		exp  = new(patched_big.Int).SetBytes(getData(input, baseLen, expLen))
-		mod  = new(patched_big.Int).SetBytes(getData(input, baseLen+expLen, modLen))
+		base = new(patched_big.Int).SetBytes(getData(contract.Input, 0, baseLen))
+		exp  = new(patched_big.Int).SetBytes(getData(contract.Input, baseLen, expLen))
+		mod  = new(patched_big.Int).SetBytes(getData(contract.Input, baseLen+expLen, modLen))
 		v    []byte
 	)
 	switch {
@@ -699,8 +849,14 @@ func (c *bn256AddIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasIstanbul
 }
 
-func (c *bn256AddIstanbul) Run(input []byte) ([]byte, error) {
-	return runBn256Add(input)
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bn256AddIstanbul) Address() common.Address {
+	return common.BytesToAddress([]byte{6})
+}
+
+func (c *bn256AddIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	return runBn256Add(contract.Input)
 }
 
 func (c *bn256AddIstanbul) Name() string {
@@ -711,13 +867,19 @@ func (c *bn256AddIstanbul) Name() string {
 // conforming to Byzantium consensus rules.
 type bn256AddByzantium struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bn256AddByzantium) Address() common.Address {
+	return common.BytesToAddress([]byte{6})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256AddByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256AddGasByzantium
 }
 
-func (c *bn256AddByzantium) Run(input []byte) ([]byte, error) {
-	return runBn256Add(input)
+func (c *bn256AddByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	return runBn256Add(contract.Input)
 }
 
 func (c *bn256AddByzantium) Name() string {
@@ -740,13 +902,19 @@ func runBn256ScalarMul(input []byte) ([]byte, error) {
 // multiplication conforming to Istanbul consensus rules.
 type bn256ScalarMulIstanbul struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bn256ScalarMulIstanbul) Address() common.Address {
+	return common.BytesToAddress([]byte{7})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256ScalarMulIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasIstanbul
 }
 
-func (c *bn256ScalarMulIstanbul) Run(input []byte) ([]byte, error) {
-	return runBn256ScalarMul(input)
+func (c *bn256ScalarMulIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	return runBn256ScalarMul(contract.Input)
 }
 
 func (c *bn256ScalarMulIstanbul) Name() string {
@@ -757,13 +925,19 @@ func (c *bn256ScalarMulIstanbul) Name() string {
 // multiplication conforming to Byzantium consensus rules.
 type bn256ScalarMulByzantium struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bn256ScalarMulByzantium) Address() common.Address {
+	return common.BytesToAddress([]byte{7})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256ScalarMulByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256ScalarMulGasByzantium
 }
 
-func (c *bn256ScalarMulByzantium) Run(input []byte) ([]byte, error) {
-	return runBn256ScalarMul(input)
+func (c *bn256ScalarMulByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	return runBn256ScalarMul(contract.Input)
 }
 
 func (c *bn256ScalarMulByzantium) Name() string {
@@ -816,13 +990,19 @@ func runBn256Pairing(input []byte) ([]byte, error) {
 // conforming to Istanbul consensus rules.
 type bn256PairingIstanbul struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bn256PairingIstanbul) Address() common.Address {
+	return common.BytesToAddress([]byte{8})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256PairingIstanbul) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasIstanbul + uint64(len(input)/192)*params.Bn256PairingPerPointGasIstanbul
 }
 
-func (c *bn256PairingIstanbul) Run(input []byte) ([]byte, error) {
-	return runBn256Pairing(input)
+func (c *bn256PairingIstanbul) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	return runBn256Pairing(contract.Input)
 }
 
 func (c *bn256PairingIstanbul) Name() string {
@@ -833,13 +1013,19 @@ func (c *bn256PairingIstanbul) Name() string {
 // conforming to Byzantium consensus rules.
 type bn256PairingByzantium struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bn256PairingByzantium) Address() common.Address {
+	return common.BytesToAddress([]byte{8})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bn256PairingByzantium) RequiredGas(input []byte) uint64 {
 	return params.Bn256PairingBaseGasByzantium + uint64(len(input)/192)*params.Bn256PairingPerPointGasByzantium
 }
 
-func (c *bn256PairingByzantium) Run(input []byte) ([]byte, error) {
-	return runBn256Pairing(input)
+func (c *bn256PairingByzantium) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	return runBn256Pairing(contract.Input)
 }
 
 func (c *bn256PairingByzantium) Name() string {
@@ -847,6 +1033,12 @@ func (c *bn256PairingByzantium) Name() string {
 }
 
 type blake2F struct{}
+
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (blake2F) Address() common.Address {
+	return common.BytesToAddress([]byte{9})
+}
 
 func (c *blake2F) RequiredGas(input []byte) uint64 {
 	// If the input is malformed, we can't calculate the gas, return 0 and let the
@@ -868,18 +1060,18 @@ var (
 	errBlake2FInvalidFinalFlag   = errors.New("invalid final flag")
 )
 
-func (c *blake2F) Run(input []byte) ([]byte, error) {
+func (c *blake2F) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Make sure the input is valid (correct length and final flag)
-	if len(input) != blake2FInputLength {
+	if len(contract.Input) != blake2FInputLength {
 		return nil, errBlake2FInvalidInputLength
 	}
-	if input[212] != blake2FNonFinalBlockBytes && input[212] != blake2FFinalBlockBytes {
+	if contract.Input[212] != blake2FNonFinalBlockBytes && contract.Input[212] != blake2FFinalBlockBytes {
 		return nil, errBlake2FInvalidFinalFlag
 	}
 	// Parse the input into the Blake2b call parameters
 	var (
-		rounds = binary.BigEndian.Uint32(input[0:4])
-		final  = input[212] == blake2FFinalBlockBytes
+		rounds = binary.BigEndian.Uint32(contract.Input[0:4])
+		final  = contract.Input[212] == blake2FFinalBlockBytes
 
 		h [8]uint64
 		m [16]uint64
@@ -887,14 +1079,14 @@ func (c *blake2F) Run(input []byte) ([]byte, error) {
 	)
 	for i := 0; i < 8; i++ {
 		offset := 4 + i*8
-		h[i] = binary.LittleEndian.Uint64(input[offset : offset+8])
+		h[i] = binary.LittleEndian.Uint64(contract.Input[offset : offset+8])
 	}
 	for i := 0; i < 16; i++ {
 		offset := 68 + i*8
-		m[i] = binary.LittleEndian.Uint64(input[offset : offset+8])
+		m[i] = binary.LittleEndian.Uint64(contract.Input[offset : offset+8])
 	}
-	t[0] = binary.LittleEndian.Uint64(input[196:204])
-	t[1] = binary.LittleEndian.Uint64(input[204:212])
+	t[0] = binary.LittleEndian.Uint64(contract.Input[196:204])
+	t[1] = binary.LittleEndian.Uint64(contract.Input[204:212])
 
 	// Execute the compression function, extract and return the result
 	blake2b.F(&h, m, t, final, rounds)
@@ -921,27 +1113,33 @@ var (
 // bls12381G1Add implements EIP-2537 G1Add precompile.
 type bls12381G1Add struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bls12381G1Add) Address() common.Address {
+	return common.BytesToAddress([]byte{11})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G1Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G1AddGas
 }
 
-func (c *bls12381G1Add) Run(input []byte) ([]byte, error) {
+func (c *bls12381G1Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G1Add precompile.
 	// > G1 addition call expects `256` bytes as an input that is interpreted as byte concatenation of two G1 points (`128` bytes each).
 	// > Output is an encoding of addition operation result - single G1 point (`128` bytes).
-	if len(input) != 256 {
+	if len(contract.Input) != 256 {
 		return nil, errBLS12381InvalidInputLength
 	}
 	var err error
 	var p0, p1 *bls12381.G1Affine
 
 	// Decode G1 point p_0
-	if p0, err = decodePointG1(input[:128]); err != nil {
+	if p0, err = decodePointG1(contract.Input[:128]); err != nil {
 		return nil, err
 	}
 	// Decode G1 point p_1
-	if p1, err = decodePointG1(input[128:]); err != nil {
+	if p1, err = decodePointG1(contract.Input[128:]); err != nil {
 		return nil, err
 	}
 
@@ -960,6 +1158,12 @@ func (c *bls12381G1Add) Name() string {
 
 // bls12381G1MultiExp implements EIP-2537 G1MultiExp precompile.
 type bls12381G1MultiExp struct{}
+
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bls12381G1MultiExp) Address() common.Address {
+	return common.BytesToAddress([]byte{12})
+}
 
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
@@ -980,12 +1184,12 @@ func (c *bls12381G1MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G1MulGas * discount) / 1000
 }
 
-func (c *bls12381G1MultiExp) Run(input []byte) ([]byte, error) {
+func (c *bls12381G1MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G1MultiExp precompile.
 	// G1 multiplication call expects `160*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G1 point (`128` bytes) and encoding of a scalar value (`32` bytes).
 	// Output is an encoding of multiexponentiation operation result - single G1 point (`128` bytes).
-	k := len(input) / 160
-	if len(input) == 0 || len(input)%160 != 0 {
+	k := len(contract.Input) / 160
+	if len(contract.Input) == 0 || len(contract.Input)%160 != 0 {
 		return nil, errBLS12381InvalidInputLength
 	}
 	points := make([]bls12381.G1Affine, k)
@@ -996,7 +1200,7 @@ func (c *bls12381G1MultiExp) Run(input []byte) ([]byte, error) {
 		off := 160 * i
 		t0, t1, t2 := off, off+128, off+160
 		// Decode G1 point
-		p, err := decodePointG1(input[t0:t1])
+		p, err := decodePointG1(contract.Input[t0:t1])
 		if err != nil {
 			return nil, err
 		}
@@ -1007,7 +1211,7 @@ func (c *bls12381G1MultiExp) Run(input []byte) ([]byte, error) {
 		}
 		points[i] = *p
 		// Decode scalar value
-		scalars[i] = *new(fr.Element).SetBytes(input[t1:t2])
+		scalars[i] = *new(fr.Element).SetBytes(contract.Input[t1:t2])
 	}
 
 	// Compute r = e_0 * p_0 + e_1 * p_1 + ... + e_(k-1) * p_(k-1)
@@ -1025,27 +1229,33 @@ func (c *bls12381G1MultiExp) Name() string {
 // bls12381G2Add implements EIP-2537 G2Add precompile.
 type bls12381G2Add struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bls12381G2Add) Address() common.Address {
+	return common.BytesToAddress([]byte{13})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G2Add) RequiredGas(input []byte) uint64 {
 	return params.Bls12381G2AddGas
 }
 
-func (c *bls12381G2Add) Run(input []byte) ([]byte, error) {
+func (c *bls12381G2Add) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G2Add precompile.
 	// > G2 addition call expects `512` bytes as an input that is interpreted as byte concatenation of two G2 points (`256` bytes each).
 	// > Output is an encoding of addition operation result - single G2 point (`256` bytes).
-	if len(input) != 512 {
+	if len(contract.Input) != 512 {
 		return nil, errBLS12381InvalidInputLength
 	}
 	var err error
 	var p0, p1 *bls12381.G2Affine
 
 	// Decode G2 point p_0
-	if p0, err = decodePointG2(input[:256]); err != nil {
+	if p0, err = decodePointG2(contract.Input[:256]); err != nil {
 		return nil, err
 	}
 	// Decode G2 point p_1
-	if p1, err = decodePointG2(input[256:]); err != nil {
+	if p1, err = decodePointG2(contract.Input[256:]); err != nil {
 		return nil, err
 	}
 
@@ -1066,6 +1276,12 @@ func (c *bls12381G2Add) Name() string {
 // bls12381G2MultiExp implements EIP-2537 G2MultiExp precompile.
 type bls12381G2MultiExp struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bls12381G2MultiExp) Address() common.Address {
+	return common.BytesToAddress([]byte{14})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
 	// Calculate G2 point, scalar value pair length
@@ -1085,12 +1301,12 @@ func (c *bls12381G2MultiExp) RequiredGas(input []byte) uint64 {
 	return (uint64(k) * params.Bls12381G2MulGas * discount) / 1000
 }
 
-func (c *bls12381G2MultiExp) Run(input []byte) ([]byte, error) {
+func (c *bls12381G2MultiExp) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 G2MultiExp precompile logic
 	// > G2 multiplication call expects `288*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes).
 	// > Output is an encoding of multiexponentiation operation result - single G2 point (`256` bytes).
-	k := len(input) / 288
-	if len(input) == 0 || len(input)%288 != 0 {
+	k := len(contract.Input) / 288
+	if len(contract.Input) == 0 || len(contract.Input)%288 != 0 {
 		return nil, errBLS12381InvalidInputLength
 	}
 	points := make([]bls12381.G2Affine, k)
@@ -1101,7 +1317,7 @@ func (c *bls12381G2MultiExp) Run(input []byte) ([]byte, error) {
 		off := 288 * i
 		t0, t1, t2 := off, off+256, off+288
 		// Decode G2 point
-		p, err := decodePointG2(input[t0:t1])
+		p, err := decodePointG2(contract.Input[t0:t1])
 		if err != nil {
 			return nil, err
 		}
@@ -1112,7 +1328,7 @@ func (c *bls12381G2MultiExp) Run(input []byte) ([]byte, error) {
 		}
 		points[i] = *p
 		// Decode scalar value
-		scalars[i] = *new(fr.Element).SetBytes(input[t1:t2])
+		scalars[i] = *new(fr.Element).SetBytes(contract.Input[t1:t2])
 	}
 
 	// Compute r = e_0 * p_0 + e_1 * p_1 + ... + e_(k-1) * p_(k-1)
@@ -1130,20 +1346,26 @@ func (c *bls12381G2MultiExp) Name() string {
 // bls12381Pairing implements EIP-2537 Pairing precompile.
 type bls12381Pairing struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bls12381Pairing) Address() common.Address {
+	return common.BytesToAddress([]byte{15})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381Pairing) RequiredGas(input []byte) uint64 {
 	return params.Bls12381PairingBaseGas + uint64(len(input)/384)*params.Bls12381PairingPerPairGas
 }
 
-func (c *bls12381Pairing) Run(input []byte) ([]byte, error) {
+func (c *bls12381Pairing) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 Pairing precompile logic.
 	// > Pairing call expects `384*k` bytes as an inputs that is interpreted as byte concatenation of `k` slices. Each slice has the following structure:
 	// > - `128` bytes of G1 point encoding
 	// > - `256` bytes of G2 point encoding
 	// > Output is a `32` bytes where last single byte is `0x01` if pairing result is equal to multiplicative identity in a pairing target field and `0x00` otherwise
 	// > (which is equivalent of Big Endian encoding of Solidity values `uint256(1)` and `uin256(0)` respectively).
-	k := len(input) / 384
-	if len(input) == 0 || len(input)%384 != 0 {
+	k := len(contract.Input) / 384
+	if len(contract.Input) == 0 || len(contract.Input)%384 != 0 {
 		return nil, errBLS12381InvalidInputLength
 	}
 
@@ -1158,12 +1380,12 @@ func (c *bls12381Pairing) Run(input []byte) ([]byte, error) {
 		t0, t1, t2 := off, off+128, off+384
 
 		// Decode G1 point
-		p1, err := decodePointG1(input[t0:t1])
+		p1, err := decodePointG1(contract.Input[t0:t1])
 		if err != nil {
 			return nil, err
 		}
 		// Decode G2 point
-		p2, err := decodePointG2(input[t1:t2])
+		p2, err := decodePointG2(contract.Input[t1:t2])
 		if err != nil {
 			return nil, err
 		}
@@ -1286,21 +1508,27 @@ func encodePointG2(p *bls12381.G2Affine) []byte {
 // bls12381MapG1 implements EIP-2537 MapG1 precompile.
 type bls12381MapG1 struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bls12381MapG1) Address() common.Address {
+	return common.BytesToAddress([]byte{16})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381MapG1) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG1Gas
 }
 
-func (c *bls12381MapG1) Run(input []byte) ([]byte, error) {
+func (c *bls12381MapG1) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 Map_To_G1 precompile.
 	// > Field-to-curve call expects an `64` bytes input that is interpreted as an element of the base field.
 	// > Output of this call is `128` bytes and is G1 point following respective encoding rules.
-	if len(input) != 64 {
+	if len(contract.Input) != 64 {
 		return nil, errBLS12381InvalidInputLength
 	}
 
 	// Decode input field element
-	fe, err := decodeBLS12381FieldElement(input)
+	fe, err := decodeBLS12381FieldElement(contract.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -1319,25 +1547,31 @@ func (c *bls12381MapG1) Name() string {
 // bls12381MapG2 implements EIP-2537 MapG2 precompile.
 type bls12381MapG2 struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (bls12381MapG2) Address() common.Address {
+	return common.BytesToAddress([]byte{17})
+}
+
 // RequiredGas returns the gas required to execute the pre-compiled contract.
 func (c *bls12381MapG2) RequiredGas(input []byte) uint64 {
 	return params.Bls12381MapG2Gas
 }
 
-func (c *bls12381MapG2) Run(input []byte) ([]byte, error) {
+func (c *bls12381MapG2) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	// Implements EIP-2537 Map_FP2_TO_G2 precompile logic.
 	// > Field-to-curve call expects an `128` bytes input that is interpreted as an element of the quadratic extension field.
 	// > Output of this call is `256` bytes and is G2 point following respective encoding rules.
-	if len(input) != 128 {
+	if len(contract.Input) != 128 {
 		return nil, errBLS12381InvalidInputLength
 	}
 
 	// Decode input field element
-	c0, err := decodeBLS12381FieldElement(input[:64])
+	c0, err := decodeBLS12381FieldElement(contract.Input[:64])
 	if err != nil {
 		return nil, err
 	}
-	c1, err := decodeBLS12381FieldElement(input[64:])
+	c1, err := decodeBLS12381FieldElement(contract.Input[64:])
 	if err != nil {
 		return nil, err
 	}
@@ -1355,6 +1589,12 @@ func (c *bls12381MapG2) Name() string {
 
 // kzgPointEvaluation implements the EIP-4844 point evaluation precompile.
 type kzgPointEvaluation struct{}
+
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (kzgPointEvaluation) Address() common.Address {
+	return common.BytesToAddress([]byte{0x0a})
+}
 
 // RequiredGas estimates the gas required for running the point evaluation precompile.
 func (b *kzgPointEvaluation) RequiredGas(input []byte) uint64 {
@@ -1374,33 +1614,33 @@ var (
 )
 
 // Run executes the point evaluation precompile.
-func (b *kzgPointEvaluation) Run(input []byte) ([]byte, error) {
-	if len(input) != blobVerifyInputLength {
+func (b *kzgPointEvaluation) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
+	if len(contract.Input) != blobVerifyInputLength {
 		return nil, errBlobVerifyInvalidInputLength
 	}
 	// versioned hash: first 32 bytes
 	var versionedHash common.Hash
-	copy(versionedHash[:], input[:])
+	copy(versionedHash[:], contract.Input[:])
 
 	var (
 		point kzg4844.Point
 		claim kzg4844.Claim
 	)
 	// Evaluation point: next 32 bytes
-	copy(point[:], input[32:])
+	copy(point[:], contract.Input[32:])
 	// Expected output: next 32 bytes
-	copy(claim[:], input[64:])
+	copy(claim[:], contract.Input[64:])
 
 	// input kzg point: next 48 bytes
 	var commitment kzg4844.Commitment
-	copy(commitment[:], input[96:])
+	copy(commitment[:], contract.Input[96:])
 	if kZGToVersionedHash(commitment) != versionedHash {
 		return nil, errBlobVerifyMismatchedVersion
 	}
 
 	// Proof: next 48 bytes
 	var proof kzg4844.Proof
-	copy(proof[:], input[144:])
+	copy(proof[:], contract.Input[144:])
 
 	if err := kzg4844.VerifyProof(commitment, point, claim, proof); err != nil {
 		return nil, fmt.Errorf("%w: %v", errBlobVerifyKZGProof, err)
@@ -1425,22 +1665,28 @@ func kZGToVersionedHash(kzg kzg4844.Commitment) common.Hash {
 // implemented as a native contract
 type p256Verify struct{}
 
+// Address defines the precompiled contract address. This MUST match the address
+// set in the precompiled contract map.
+func (p256Verify) Address() common.Address {
+	return common.BytesToAddress([]byte{0x1, 0x00})
+}
+
 // RequiredGas returns the gas required to execute the precompiled contract
 func (c *p256Verify) RequiredGas(input []byte) uint64 {
 	return params.P256VerifyGas
 }
 
 // Run executes the precompiled contract with given 160 bytes of param, returning the output and the used gas
-func (c *p256Verify) Run(input []byte) ([]byte, error) {
+func (c *p256Verify) Run(evm *EVM, contract *Contract, readonly bool) ([]byte, error) {
 	const p256VerifyInputLength = 160
-	if len(input) != p256VerifyInputLength {
+	if len(contract.Input) != p256VerifyInputLength {
 		return nil, nil
 	}
 
 	// Extract hash, r, s, x, y from the input.
-	hash := input[0:32]
-	r, s := new(big.Int).SetBytes(input[32:64]), new(big.Int).SetBytes(input[64:96])
-	x, y := new(big.Int).SetBytes(input[96:128]), new(big.Int).SetBytes(input[128:160])
+	hash := contract.Input[0:32]
+	r, s := new(big.Int).SetBytes(contract.Input[32:64]), new(big.Int).SetBytes(contract.Input[64:96])
+	x, y := new(big.Int).SetBytes(contract.Input[96:128]), new(big.Int).SetBytes(contract.Input[128:160])
 
 	// Verify the signature.
 	if secp256r1.Verify(hash, r, s, x, y) {

--- a/core/vm/contracts_fuzz_test.go
+++ b/core/vm/contracts_fuzz_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
 )
 
 func FuzzPrecompiledContracts(f *testing.F) {
@@ -36,7 +37,7 @@ func FuzzPrecompiledContracts(f *testing.F) {
 			return
 		}
 		inWant := string(input)
-		RunPrecompiledContract(p, input, gas, nil)
+		runPrecompiledContract(nil, p, AccountRef(common.Address{}), input, gas, new(uint256.Int), false)
 		if inHave := string(input); inWant != inHave {
 			t.Errorf("Precompiled %v modified input data", a)
 		}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"testing"
 	"time"
+	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -99,7 +100,7 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		if res, _, err := RunPrecompiledContract(p, in, gas, nil); err != nil {
+		if res, _, err := runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, gas, new(uint256.Int), false); err != nil {
 			t.Error(err)
 		} else if common.Bytes2Hex(res) != test.Expected {
 			t.Errorf("Expected %v, got %v", test.Expected, common.Bytes2Hex(res))
@@ -121,7 +122,7 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 	gas := test.Gas - 1
 
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.Name, gas), func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas, nil)
+		_, _, err := runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, gas, new(uint256.Int), false)
 		if err.Error() != "out of gas" {
 			t.Errorf("Expected error [out of gas], got [%v]", err)
 		}
@@ -138,7 +139,7 @@ func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing
 	in := common.Hex2Bytes(test.Input)
 	gas := p.RequiredGas(in)
 	t.Run(test.Name, func(t *testing.T) {
-		_, _, err := RunPrecompiledContract(p, in, gas, nil)
+		_, _, err := runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, gas, new(uint256.Int), false)
 		if err.Error() != test.ExpectedError {
 			t.Errorf("Expected error [%v], got [%v]", test.ExpectedError, err)
 		}
@@ -169,7 +170,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		start := time.Now()
 		for bench.Loop() {
 			copy(data, in)
-			res, _, err = RunPrecompiledContract(p, data, reqGas, nil)
+			res, _, err = runPrecompiledContract(nil, p, AccountRef(common.Address{}), in, reqGas, new(uint256.Int), false)
 		}
 		elapsed := uint64(time.Since(start))
 		if elapsed < 1 {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -122,6 +122,9 @@ type EVM struct {
 	// precompiles holds the precompiled contracts for the current epoch
 	precompiles map[common.Address]PrecompiledContract
 
+	// activePrecompiles defines the precompiles that are currently active
+	activePrecompiles []common.Address
+
 	// jumpDests stores results of JUMPDEST analysis.
 	jumpDests JumpDestCache
 
@@ -146,7 +149,9 @@ func NewEVM(blockCtx BlockContext, statedb StateDB, chainConfig *params.ChainCon
 		jumpDests:   newMapJumpDests(),
 		hasher:      crypto.NewKeccakState(),
 	}
+
 	evm.precompiles = activePrecompiledContracts(evm.chainRules)
+	evm.activePrecompiles = DefaultActivePrecompiles(evm.chainRules)
 
 	switch {
 	case evm.chainRules.IsOsaka:
@@ -181,6 +186,7 @@ func NewEVM(blockCtx BlockContext, statedb StateDB, chainConfig *params.ChainCon
 	default:
 		evm.table = &frontierInstructionSet
 	}
+
 	var extraEips []int
 	if len(evm.Config.ExtraEips) > 0 {
 		// Deep-copy jumptable to prevent modification of opcodes in other tables
@@ -255,7 +261,7 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 		return nil, gas, ErrInsufficientBalance
 	}
 	snapshot := evm.StateDB.Snapshot()
-	p, isPrecompile := evm.precompile(addr)
+	p, isPrecompile := evm.Precompile(addr)
 
 	if !evm.StateDB.Exist(addr) {
 		if !isPrecompile && evm.chainRules.IsEIP4762 && !isSystemCall(caller) {
@@ -282,8 +288,9 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 	}
 	evm.Context.Transfer(evm.StateDB, caller, addr, value)
 
+	// It is allowed to call precompiles, even via call -- as opposed to callcode, staticcall and delegatecall it can also modify state
 	if isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+			ret, gas, err = evm.RunPrecompiledContract(p, AccountRef(caller), input, gas, value, false)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		code := evm.resolveCode(addr)
@@ -345,9 +352,9 @@ func (evm *EVM) CallCode(caller common.Address, addr common.Address, input []byt
 	}
 	var snapshot = evm.StateDB.Snapshot()
 
-	// It is allowed to call precompiles, even via delegatecall
-	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+	// It is allowed to call precompiles, even via callcode, but only for reading
+	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
+		ret, gas, err = evm.RunPrecompiledContract(p, AccountRef(caller), input, gas, value, true)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
@@ -389,8 +396,8 @@ func (evm *EVM) DelegateCall(originCaller common.Address, caller common.Address,
 	var snapshot = evm.StateDB.Snapshot()
 
 	// It is allowed to call precompiles, even via delegatecall
-	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
+		ret, gas, err = evm.RunPrecompiledContract(p, AccountRef(caller), input, gas, nil, true)
 	} else {
 		// Initialise a new contract and make initialise the delegate values
 		//
@@ -441,8 +448,8 @@ func (evm *EVM) StaticCall(caller common.Address, addr common.Address, input []b
 	// future scenarios
 	evm.StateDB.AddBalance(addr, new(uint256.Int), tracing.BalanceChangeTouchAccount)
 
-	if p, isPrecompile := evm.precompile(addr); isPrecompile {
-		ret, gas, err = RunPrecompiledContract(p, input, gas, evm.Config.Tracer)
+	if p, isPrecompile := evm.Precompile(addr); isPrecompile {
+		ret, gas, err = evm.RunPrecompiledContract(p, AccountRef(caller), input, gas, new(uint256.Int), true)
 	} else {
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.

--- a/core/vm/operations_verkle.go
+++ b/core/vm/operations_verkle.go
@@ -39,7 +39,7 @@ func gasBalance4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, mem
 
 func gasExtCodeSize4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	address := stack.peek().Bytes20()
-	if _, isPrecompile := evm.precompile(address); isPrecompile {
+	if _, isPrecompile := evm.Precompile(address); isPrecompile {
 		return 0, nil
 	}
 	return evm.AccessEvents.BasicDataGas(address, false, contract.Gas, true), nil
@@ -47,7 +47,7 @@ func gasExtCodeSize4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory,
 
 func gasExtCodeHash4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	address := stack.peek().Bytes20()
-	if _, isPrecompile := evm.precompile(address); isPrecompile {
+	if _, isPrecompile := evm.Precompile(address); isPrecompile {
 		return 0, nil
 	}
 	return evm.AccessEvents.CodeHashGas(address, false, contract.Gas, true), nil
@@ -58,7 +58,7 @@ func makeCallVariantGasEIP4762(oldCalculator gasFunc, withTransferCosts bool) ga
 		var (
 			target           = common.Address(stack.Back(1).Bytes20())
 			witnessGas       uint64
-			_, isPrecompile  = evm.precompile(target)
+			_, isPrecompile  = evm.Precompile(target)
 			isSystemContract = target == params.HistoryStorageAddress
 		)
 
@@ -109,7 +109,7 @@ var (
 
 func gasSelfdestructEIP4762(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	beneficiaryAddr := common.Address(stack.peek().Bytes20())
-	if _, isPrecompile := evm.precompile(beneficiaryAddr); isPrecompile {
+	if _, isPrecompile := evm.Precompile(beneficiaryAddr); isPrecompile {
 		return 0, nil
 	}
 	if contract.IsSystemCall {
@@ -122,7 +122,7 @@ func gasSelfdestructEIP4762(evm *EVM, contract *Contract, stack *Stack, mem *Mem
 	}
 	statelessGas := wanted
 	balanceIsZero := evm.StateDB.GetBalance(contractAddr).Sign() == 0
-	_, isPrecompile := evm.precompile(beneficiaryAddr)
+	_, isPrecompile := evm.Precompile(beneficiaryAddr)
 	isSystemContract := beneficiaryAddr == params.HistoryStorageAddress
 
 	if (isPrecompile || isSystemContract) && balanceIsZero {
@@ -188,7 +188,7 @@ func gasExtCodeCopyEIP4762(evm *EVM, contract *Contract, stack *Stack, mem *Memo
 		return 0, err
 	}
 	addr := common.Address(stack.peek().Bytes20())
-	_, isPrecompile := evm.precompile(addr)
+	_, isPrecompile := evm.Precompile(addr)
 	if isPrecompile || addr == params.HistoryStorageAddress {
 		var overflow bool
 		if gas, overflow = math.SafeAdd(gas, params.WarmStorageReadCostEIP2929); overflow {

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -137,7 +137,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 	// Execute the preparatory steps for state transition which includes:
 	// - prepare accessList(post-berlin)
 	// - reset transient storage(eip 1153)
-	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
+	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, &address, vm.DefaultActivePrecompiles(rules), nil)
 	cfg.State.CreateAccount(address)
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(address, code, tracing.CodeChangeUnspecified)
@@ -175,7 +175,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 	// Execute the preparatory steps for state transition which includes:
 	// - prepare accessList(post-berlin)
 	// - reset transient storage(eip 1153)
-	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, nil, vm.ActivePrecompiles(rules), nil)
+	cfg.State.Prepare(rules, cfg.Origin, cfg.Coinbase, nil, vm.DefaultActivePrecompiles(rules), nil)
 	// Call the code with the given configuration.
 	code, address, leftOverGas, err := vmenv.Create(
 		cfg.Origin,
@@ -208,7 +208,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 	// Execute the preparatory steps for state transition which includes:
 	// - prepare accessList(post-berlin)
 	// - reset transient storage(eip 1153)
-	statedb.Prepare(rules, cfg.Origin, cfg.Coinbase, &address, vm.ActivePrecompiles(rules), nil)
+	statedb.Prepare(rules, cfg.Origin, cfg.Coinbase, &address, vm.DefaultActivePrecompiles(rules), nil)
 
 	// Call the code with the given configuration.
 	ret, leftOverGas, err := vmenv.Call(

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -257,7 +257,7 @@ func (t *jsTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from
 	t.dbValue = db.setupObject()
 	// Update list of precompiles based on current block
 	rules := t.chainConfig.Rules(env.BlockNumber, env.Random != nil, env.Time)
-	t.activePrecompiles = vm.ActivePrecompiles(rules)
+	t.activePrecompiles = vm.DefaultActivePrecompiles(rules)
 	t.ctx["block"] = t.vm.ToValue(t.env.BlockNumber.Uint64())
 	t.ctx["gas"] = t.vm.ToValue(tx.Gas())
 	gasTip, _ := tx.EffectiveGasTip(env.BaseFee)

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -92,7 +92,7 @@ func (t *fourByteTracer) store(id []byte, size int) {
 func (t *fourByteTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	// Update list of precompiles based on current block
 	rules := t.chainConfig.Rules(env.BlockNumber, env.Random != nil, env.Time)
-	t.activePrecompiles = vm.ActivePrecompiles(rules)
+	t.activePrecompiles = vm.DefaultActivePrecompiles(rules)
 }
 
 // OnEnter is called when EVM enters a new scope (via call, create or selfdestruct).

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -208,7 +208,7 @@ func (t *flatCallTracer) OnTxStart(env *tracing.VMContext, tx *types.Transaction
 	t.tracer.OnTxStart(env, tx, from)
 	// Update list of precompiles based on current block
 	rules := t.chainConfig.Rules(env.BlockNumber, env.Random != nil, env.Time)
-	t.activePrecompiles = vm.ActivePrecompiles(rules)
+	t.activePrecompiles = vm.DefaultActivePrecompiles(rules)
 }
 
 func (t *flatCallTracer) OnTxEnd(receipt *types.Receipt, err error) {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1276,7 +1276,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	}
 	isPostMerge := header.Difficulty.Sign() == 0
 	// Retrieve the precompiles since they don't need to be added to the access list
-	precompiles := vm.ActivePrecompiles(b.ChainConfig().Rules(header.Number, isPostMerge, header.Time))
+	precompiles := vm.DefaultActivePrecompiles(b.ChainConfig().Rules(header.Number, isPostMerge, header.Time))
 
 	// addressesToExclude contains sender, receiver, precompiles and valid authorizations
 	addressesToExclude := map[common.Address]struct{}{args.from(): {}, to: {}}

--- a/internal/ethapi/override/override_test.go
+++ b/internal/ethapi/override/override_test.go
@@ -31,9 +31,13 @@ import (
 
 type precompileContract struct{}
 
+func (p *precompileContract) Address() common.Address { return common.Address{} }
+
 func (p *precompileContract) RequiredGas(input []byte) uint64 { return 0 }
 
-func (p *precompileContract) Run(input []byte) ([]byte, error) { return nil, nil }
+func (p *precompileContract) Run(evm *vm.EVM, contract *vm.Contract, readonly bool) ([]byte, error) {
+	return nil, nil
+}
 
 func (p *precompileContract) Name() string {
 	panic("implement me")

--- a/tests/fuzzers/bls12381/precompile_fuzzer.go
+++ b/tests/fuzzers/bls12381/precompile_fuzzer.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
 )
 
 const (
@@ -76,7 +77,9 @@ func fuzz(id byte, data []byte) int {
 	}
 	cpy := make([]byte, len(data))
 	copy(cpy, data)
-	_, err := precompile.Run(cpy)
+	contract := vm.NewPrecompile(vm.AccountRef(common.Address{}), precompile, new(uint256.Int).SetUint64(0), gas)
+	contract.Input = cpy
+	_, err := precompile.Run(nil, contract, false)
 	if !bytes.Equal(cpy, data) {
 		panic(fmt.Sprintf("input data modified, precompile %d: %x %x", id, data, cpy))
 	}

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -311,7 +311,7 @@ func runBenchmark(b *testing.B, t *StateTest) {
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
 				snapshot := state.StateDB.Snapshot()
-				state.StateDB.Prepare(rules, msg.From, context.Coinbase, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
+				state.StateDB.Prepare(rules, msg.From, context.Coinbase, msg.To, vm.DefaultActivePrecompiles(rules), msg.AccessList)
 				b.StartTimer()
 				start := time.Now()
 


### PR DESCRIPTION
#References: https://linear.app/thesis-co/issue/MEZO-3233/dry-run-upgrade-of-go-ethereum-upgrade

### Description

This PR applies Mezo’s Adding custom precompiled support commit (3d0e225ba11369bcfd3e4350d3638487f8c02018, carried here as a0ce43a80f048487c8b9a992d9084756e12510b5) on top of upstream `go-ethereum v1.16.8` (`abeb78c64`), i.e. on a `v1.16.8` base instead of the old `v1.14.8` base.

The previous Mezo fix precompiles addresses commit (`2836c12d66ebbca959255235fe40e9cb5c111457`) is not cherry-picked as a separate commit; its intent is included in the conflict-resolved port result.


