### PR TITLE
Add CanReceiveTransfer recipient-side transfer guard

### DIFF
--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -28,6 +28,7 @@ var (
 	ErrCodeStoreOutOfGas        = errors.New("contract creation code storage out of gas")
 	ErrDepth                    = errors.New("max call depth exceeded")
 	ErrInsufficientBalance      = errors.New("insufficient balance for transfer")
+	ErrTransferNotAllowed       = errors.New("transfer not allowed to recipient")
 	ErrContractAddressCollision = errors.New("contract address collision")
 	ErrExecutionReverted        = errors.New("execution reverted")
 	ErrMaxCodeSizeExceeded      = errors.New("max code size exceeded")

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -34,6 +34,10 @@ import (
 type (
 	// CanTransferFunc is the signature of a transfer guard function
 	CanTransferFunc func(StateDB, common.Address, *uint256.Int) bool
+	// CanReceiveTransferFunc is the signature of a recipient-side transfer
+	// guard function. The address argument is the recipient (credited
+	// account), not the sender.
+	CanReceiveTransferFunc func(StateDB, common.Address, *uint256.Int) bool
 	// TransferFunc is the signature of a transfer function
 	TransferFunc func(StateDB, common.Address, common.Address, *uint256.Int)
 	// GetHashFunc returns the n'th block hash in the blockchain
@@ -61,6 +65,14 @@ type BlockContext struct {
 	BaseFee     *big.Int       // Provides information for BASEFEE (0 if vm runs with NoBaseFee flag and 0 gas price)
 	BlobBaseFee *big.Int       // Provides information for BLOBBASEFEE (0 if vm runs with NoBaseFee flag and 0 blob gas price)
 	Random      *common.Hash   // Provides information for PREVRANDAO
+
+	// CanReceiveTransfer is a Mezo-specific fork addition (does not exist
+	// in upstream go-ethereum). Optional recipient-side guard invoked by
+	// Call to fail-fast on transfers the host chain refuses to credit.
+	// Nil-safe: a nil value disables the check, preserving upstream
+	// behavior. NewEVMBlockContext leaves it nil; only chain integrators
+	// (e.g. mezod) populate it.
+	CanReceiveTransfer CanReceiveTransferFunc
 }
 
 // TxContext provides the EVM with information about a transaction.
@@ -248,6 +260,19 @@ func (evm *EVM) Call(caller common.Address, addr common.Address, input []byte, g
 	// Fail if we're trying to transfer more than the available balance
 	if !value.IsZero() && !evm.Context.CanTransfer(evm.StateDB, caller, value) {
 		return nil, gas, ErrInsufficientBalance
+	}
+	// Recipient-side guard (Mezo-specific fork addition; nil-safe). Gated
+	// in Call only: DelegateCall and StaticCall perform no value transfer,
+	// CallCode credits the caller rather than the target, and CREATE /
+	// CREATE2 credit a freshly-derived contract address that by construction
+	// cannot collide with the well-known host-chain accounts (module
+	// accounts, etc.) that this guard is intended to protect — so none of
+	// those frames need the check. Placed before the StateDB snapshot so
+	// a refusal aborts the frame cleanly with no state mutation, instead
+	// of being caught at commit time.
+	if !value.IsZero() && evm.Context.CanReceiveTransfer != nil &&
+		!evm.Context.CanReceiveTransfer(evm.StateDB, addr, value) {
+		return nil, gas, ErrTransferNotAllowed
 	}
 	snapshot := evm.StateDB.Snapshot()
 	p, isPrecompile := evm.precompile(addr)

--- a/core/vm/evm_test.go
+++ b/core/vm/evm_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEVMCallCanReceiveTransferGuard verifies that a non-nil
+// CanReceiveTransfer returning false aborts a value-bearing CALL with
+// ErrTransferNotAllowed before any state mutation: gas is left intact,
+// the recipient is not created, and Transfer is not invoked.
+func TestEVMCallCanReceiveTransferGuard(t *testing.T) {
+	var (
+		caller    = common.HexToAddress("0x01")
+		recipient = common.HexToAddress("0x02")
+		gas       = uint64(100_000)
+		value     = uint256.NewInt(1)
+	)
+
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	require.NoError(t, err)
+
+	var transferCalled bool
+	evm := NewEVM(BlockContext{
+		CanTransfer: func(StateDB, common.Address, *uint256.Int) bool {
+			return true
+		},
+		CanReceiveTransfer: func(StateDB, common.Address, *uint256.Int) bool {
+			return false
+		},
+		Transfer: func(StateDB, common.Address, common.Address, *uint256.Int) {
+			transferCalled = true
+		},
+	}, statedb, params.AllEthashProtocolChanges, Config{})
+
+	_, leftOverGas, err := evm.Call(caller, recipient, nil, gas, value)
+
+	require.True(t, errors.Is(err, ErrTransferNotAllowed))
+	require.Equal(t, gas, leftOverGas)
+	require.False(t, statedb.Exist(recipient))
+	require.False(t, transferCalled)
+}
+
+// TestEVMCallCanReceiveTransferGuardIgnoresZeroValue verifies that the
+// recipient-side guard is short-circuited by the value.IsZero() check
+// and is not invoked for zero-value CALLs.
+func TestEVMCallCanReceiveTransferGuardIgnoresZeroValue(t *testing.T) {
+	var (
+		caller    = common.HexToAddress("0x01")
+		recipient = common.HexToAddress("0x02")
+		gas       = uint64(100_000)
+		value     = uint256.NewInt(0)
+	)
+
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	require.NoError(t, err)
+
+	var guardCalled bool
+	evm := NewEVM(BlockContext{
+		CanTransfer: func(StateDB, common.Address, *uint256.Int) bool {
+			return true
+		},
+		CanReceiveTransfer: func(StateDB, common.Address, *uint256.Int) bool {
+			guardCalled = true
+			return false
+		},
+		Transfer: func(StateDB, common.Address, common.Address, *uint256.Int) {},
+	}, statedb, params.AllEthashProtocolChanges, Config{})
+
+	_, _, err = evm.Call(caller, recipient, nil, gas, value)
+
+	require.NoError(t, err)
+	require.False(t, guardCalled)
+}


### PR DESCRIPTION
References: [MEZO-4351](https://linear.app/thesis-co/issue/MEZO-4351/missing-blockedaddrs-validation-in-the-transfer-wiring-logic)

## Introduction

Upstream go-ethereum only checks whether the **sender** can spend (`CanTransfer`); there is no symmetric hook to check whether the **recipient** is allowed to be credited. Chains whose host layer maintains a blocked-recipient set (e.g. mezod's `BlockedAddrs` on the bank module) cannot reject such transfers at the EVM frame boundary, so a value-bearing `CALL` to a blocked address runs through the frame and is only refused at commit time. Refusing the credit later — after the frame has already snapshotted and mutated state — produces a worse failure mode than failing fast: the revert path is the wrong shape (commit-time host error vs. clean frame revert), gas accounting is harder to reason about, and the EVM has already done work that ends up discarded.

## Changes

`core/vm/evm.go` introduces a new `CanReceiveTransferFunc` type and an optional `CanReceiveTransfer` field on `BlockContext`, mirroring the existing `CanTransferFunc` / `CanTransfer` pair but with the address argument bound to the **recipient** rather than the sender. The guard is invoked inside `(*EVM).Call`, positioned immediately after the sender-side `CanTransfer` check and before the `StateDB.Snapshot()`, so a refusal aborts the frame before any state mutation occurs. On refusal the frame returns the new sentinel `ErrTransferNotAllowed` (added to `core/vm/errors.go`) with the full input gas, identical in shape to the existing `ErrInsufficientBalance` return.

The field is nil-safe: a nil `CanReceiveTransfer` disables the check entirely, so consumers that do not populate it (including the default `NewEVMBlockContext` in `core/evm.go`, which is left unchanged) see no behavioral difference from upstream. Only chain integrators that wire a non-nil callback opt in. The check is also value-gated — `!value.IsZero()` short-circuits before the nil load on the dominant valueless-call path, keeping the hot path free of any new indirect call for valueless CALLs.

Scope is deliberately confined to `Call`. `CallCode`, `DelegateCall`, and `StaticCall` are unchanged: `DelegateCall` and `StaticCall` perform no value transfer, and `CallCode` credits `caller` (not `addr`), so the recipient-guard semantics do not apply.

## Testing

- `go build ./core/...` — clean.
- `go test ./core/vm/` — passes (3.979s); the existing core/vm test suite covers the CALL frame path and remains green with the additive change.

The new guard is exercised end-to-end by the integrating chain (mezod), which wires its bank-module `BlockedAddrs` check into the callback; that integration is the load-bearing test for the recipient-side semantics and lives in the mezod repo.
